### PR TITLE
fix endian tag

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -106,7 +106,7 @@ pub fn build(b: *std.Build) void {
         ._POSIX_PTHREAD_SEMANTICS = 1,
         ._TANDEM_SOURCE = 1,
         .__EXTENSIONS__ = 1,
-        .WORDS_BIGENDIAN = have(t.cpu.arch.endian() == .Big),
+        .WORDS_BIGENDIAN = have(t.cpu.arch.endian() == .big),
         .VERSION = version,
         .WITH_DMALLOC = null,
         ._FILE_OFFSET_BITS = null,


### PR DESCRIPTION
As per https://github.com/ziglang/zig/commit/3fc6fc68129219a026ae3d7dff82513758e33a21 the tags are now in lower-case.