### PR TITLE
Update build to zig 15

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,14 +6,17 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const t = target.result;
 
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "mp3lame",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = .static,
     });
 
     const config_header = b.addConfigHeader(.{
-        .style = .{ .autoconf = b.path("config.h.in") },
+        .style = .{ .autoconf_undef = b.path("config.h.in") },
     }, .{
         .ABORTFP = null,
         .AC_APPLE_UNIVERSAL_BUILD = null,


### PR DESCRIPTION
This updates the build to 0.15 standards and also as a side effect, it seems to fix #1 
Verified with `~/src/zig-aarch64-macos-0.15.0-dev.1092+d772c0627/zig build`.
I don't know much zig, so I was looking around for projects to see/learn, found ffmpeg and noticed that it won't compile on aarch64 using 0.14 nor with 0.15.
If that looks ok, let me know, and I can try to do the same for the other dependencies.
